### PR TITLE
Add support for ActiveAdmin v1.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.0.1
+
+- Add support for ActiveAdmin v1.0.0
+   - Add custom `belongs_to` override to Pages
+
 ## 1.0.0
 
 - Rename subnav.css.scss to subnav.scss to avoid Sprockets deprecation warning

--- a/lib/active_admin/subnav.rb
+++ b/lib/active_admin/subnav.rb
@@ -18,12 +18,9 @@ module ActiveAdmin
   end
 end
 
-
 # Register a TabbedNavigation view for the sub navigation.
 ActiveAdmin::ViewFactory.register sub_navigation: ActiveAdmin::Views::TabbedNavigation,
                                   header:         ActiveAdmin::Views::HeaderWithSubnav
-
-ActiveAdmin::Page.send :include, ActiveAdmin::Subnav::Page
 
 ActiveAdmin.after_load do
   ActiveAdmin::BaseController.send :include, ActiveAdmin::Subnav::MenuExtensions

--- a/lib/active_admin/subnav/extensions/page.rb
+++ b/lib/active_admin/subnav/extensions/page.rb
@@ -1,11 +1,13 @@
 module ActiveAdmin
-  module Subnav
-    module Page
-      extend ActiveSupport::Concern
+  class Page
+    def belongs_to(target, options = {})
+      @belongs_to = Resource::BelongsTo.new(self, target, options)
+      self.sub_navigation_menu_name = target
+      controller.send :belongs_to, target, options.dup
+    end
 
-      def show_sub_menu?(*)
-        false
-      end
+    def show_sub_menu?(*)
+      false
     end
   end
 end

--- a/lib/active_admin/subnav/extensions/resource.rb
+++ b/lib/active_admin/subnav/extensions/resource.rb
@@ -1,7 +1,5 @@
 module ActiveAdmin
   class Resource
-
-    # TODO: Support for optional belongs_to
     def belongs_to(target, options = {})
       @belongs_to = Resource::BelongsTo.new(self, target, options)
       self.sub_navigation_menu_name = target

--- a/lib/active_admin/subnav/version.rb
+++ b/lib/active_admin/subnav/version.rb
@@ -1,5 +1,5 @@
 module Activeadmin
   module Subnav
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
Adds override for `ActiveAdmin::Page.belongs_to` for pages within the subnav. Also upgrade the version to v1.0.1.