### PR TITLE
Use header-item in classes for consistency

### DIFF
--- a/lib/active_admin/subnav/views/header_with_subnav.rb
+++ b/lib/active_admin/subnav/views/header_with_subnav.rb
@@ -35,7 +35,7 @@ module ActiveAdmin
         if has_sub_nav?
           div class: "subnav" do
             menu = active_admin_config.sub_navigation_menu
-            insert_tag view_factory.sub_navigation, menu, :class => "tabs"
+            insert_tag view_factory.sub_navigation, menu, class: "header-item tabs"
           end
         end
       end


### PR DESCRIPTION
The other navigation tab sections include `tabs` and `header-item` in their class lists. Subnav should also include this class so styles can be applied evenly for all header items (since `tabs` is used elsewhere in Active Admin).