### PR TITLE
Add support for pages in subnav with belongs_to

### DIFF
--- a/lib/active_admin/subnav/extensions/page.rb
+++ b/lib/active_admin/subnav/extensions/page.rb
@@ -9,5 +9,9 @@ module ActiveAdmin
     def show_sub_menu?(*)
       false
     end
+
+    def has_nested_resources?
+      false
+    end
   end
 end

--- a/spec/subnav_spec.rb
+++ b/spec/subnav_spec.rb
@@ -51,6 +51,10 @@ describe "activeadmin-subnav" do
     it "to never show sub menus" do
       expect(page.show_sub_menu?).to_equal false
     end
+
+    it "to never have nested resources" do
+      expect(page.has_nested_resources?).to_equal false
+    end
   end
 
   describe "extends Resource" do


### PR DESCRIPTION
First off, thanks for this gem! It's really helped us organize our backend in a much more manageable way.

While customizing our app we found out that the combination of `ActiveAdmin::Page`s  and [`belongs_to`](https://activeadmin.info/2-resource-customization.html#belongs-to) currently doesn't work. This is because `HeaderWithSubnav#has_sub_nav?` will also [try to call `#has_nested_resources`](https://github.com/zorab47/active_admin-subnav/blob/86ea860c28e39219f6cc07c273ab710fbcf79322/lib/active_admin/subnav/views/header_with_subnav.rb#L56) on an `ActiveAdmin::Page` object if it belongs to a parent resource.

This PR make that possible.

@zorab47 Incidentally, I found it very difficult to get the tests working and was only able to do so with quite a few changes (see [here](https://github.com/edennis/active_admin-subnav/commit/3f393970e7839f4ed7d0f461c440969070fc7206)). Just out of curiosity, how do you normally go about running them?